### PR TITLE
Feature/List Spaces 

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,15 @@ is completed as that is what will connect all the tables together and have a wor
 ```
 python manage.py test sharedspaces.tests.TestSpaceDateTime
 ```
+<br>
+
+#### List spaces Background:
+List out the spaces in the user account was mostly already complete but what was needed to be added were a few buttons.
+So, a few buttons were added and with that the ability to edit and add time/date for the space. 
+
+##### List spaces Testing:
+The test mainly checks that the functionality required for the card is working correctly. This involves making sure
+that the space connected to the user can be retrieved easily. The testing for actual front end is not added.
+```
+python manage.py test sharedspaces.tests.ListSpacesTest
+```

--- a/sadcowpng/sharedspaces/static/spaces.css
+++ b/sadcowpng/sharedspaces/static/spaces.css
@@ -16,6 +16,7 @@
 
   .create_space_table, .update_space_table, .space_date_time_table{
       width: 800px;
+      color: white;
   }
 
   .space_submit_button{
@@ -50,4 +51,13 @@
       text-align: center;
       color: white;
   }
+
+  .card-title{
+      color: black;
+  }
+
+  .date-title{
+      color: black;
+  }
+
 

--- a/sadcowpng/sharedspaces/templates/sharedspaces/account.html
+++ b/sadcowpng/sharedspaces/templates/sharedspaces/account.html
@@ -21,13 +21,12 @@
             <h3>My Listings</h3>
             <div class="row">
                 {% for spaces in space %}
-                    <div class="col-sm-5">
-                        <div class="card">
-                            <div class="card-body">
-                                <h5 class="card-title">{{ spaces.space_name }}</h5>
-                                <p class="card-text">{{ spaces.space_description }}</p>
-                                <a href="{% url 'update_space' spaces.id %}" class="btn btn-primary">Update Space</a>
-                            </div>
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">{{ spaces.space_name }}</h5>
+                            <p class="card-text">{{ spaces.space_description }}</p>
+                            <a href="{% url 'date_time' spaces.id %}" class="btn btn-primary">Edit Time</a>
+                            <a href="{% url 'update_space' spaces.id %}" class="btn btn-primary">Update Space</a>
                         </div>
                     </div>
                 {% endfor %}

--- a/sadcowpng/sharedspaces/templates/sharedspaces/date_time.html
+++ b/sadcowpng/sharedspaces/templates/sharedspaces/date_time.html
@@ -1,0 +1,44 @@
+{% load static %}
+
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Date Time Listing</title>
+
+        <!-- Bootstrap CSS -->
+        <link crossorigin="anonymous"
+              href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css"
+              integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6"
+              rel="stylesheet">
+
+        <link rel="stylesheet" type="text/css" href="{% static 'spaces.css' %}">
+
+        <!-- favicon -->
+        <link rel="shortcut icon" type="image/png" href="{% static 'logo2-dark.png' %}"/>
+
+    </head>
+    <body>
+        <div class="container-fluid">
+            {% if user.is_proprietor and user.is_authenticated %}
+            <h3 class="date-title"> Dates and times for {{space.space_name}}</h3>
+            <a href="{% url 'space_date_time' space.id %}"
+                    class="btn btn-secondary btn-lg btn-block">Add a new Date and Time</a>
+            <br>
+            <br>
+            <div class="row">
+                {% for date_time in date_times %}
+                    <div class="card">
+                        <div class="card-body">
+                            <h5 class="card-title">Date: {{date_time.space_date}}
+                                Time: {{date_time.space_start_time}}
+                            </h5>
+                            <a href="{% url 'update_date_time' date_time.id %}" class="btn btn-primary">Deactivate</a>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+    </body>
+</html>

--- a/sadcowpng/sharedspaces/templates/sharedspaces/update_space_date_time.html
+++ b/sadcowpng/sharedspaces/templates/sharedspaces/update_space_date_time.html
@@ -4,7 +4,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
-        <title>Create availabilities for your Shared Space!</title>
+        <title>Update Date and Time</title>
 
         <!-- Bootstrap CSS -->
         <link crossorigin="anonymous"

--- a/sadcowpng/sharedspaces/urls.py
+++ b/sadcowpng/sharedspaces/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     path('logout/', views.sign_out, name='logout'),
     path('space_times/<space_id>', views.space_date_time, name='space_date_time'),
     path('space_update_times/<data_time_id>', views.update_space_date_time, name='update_date_time'),
+    path('date_time/<space_id>', views.date_time, name='date_time'),
 ]

--- a/sadcowpng/sharedspaces/views.py
+++ b/sadcowpng/sharedspaces/views.py
@@ -258,3 +258,23 @@ def update_space_date_time(request, data_time_id):
                    "id": data_time_id}
 
     return render(request, 'sharedspaces/update_space_date_time.html', context=context)
+
+
+@login_required
+def date_time(request, space_id):
+    """
+    The handles the listing of date and time for each location
+    """
+    if request.user.is_proprietor:
+        date_times = SpaceDateTime.objects.filter(space_id=space_id)
+        space = Space.objects.get(pk=space_id)
+
+        context = {
+            'date_times': date_times,
+            'space': space
+        }
+    else:
+        return HttpResponseRedirect(reverse('account'))
+
+    return render(request, 'sharedspaces/date_time.html', context=context)
+


### PR DESCRIPTION
This is for story #19 
This basically took the spaces that are assigned or created by each proprietor and made them show up on the account page for the specific proprietor. This was mostly already done by Binh. But we were missing a few things to make it fully functional. As we were missing a button that connects it to the times. I added that and also made a page for the said time and dates to show up in an orderly manner. It is shown in the order of the primary key. That will be fixed later on.

Testing:
one main test is done for this and it is to make sure users and spaces are connected.
That test is in test.py: ListSpacesTest
